### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/github/license/LGro/PyAPSI)](https://github.com/LGro/PyAPSI/blob/main/LICENSE)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
-Python wrapper for labeled and unlabeled asynchronous private set intersection
+Python wrapper for labeled and unlabeled asymmetric private set intersection
 ([APSI](https://github.com/microsoft/apsi)).
 
 ## Setup


### PR DESCRIPTION
[APSI](https://github.com/microsoft/APSI) stands for Asymmetric Private Set Intersection. Unless I'm missing some special asynchronous functionality added by the wrapper the full form of APSI should remain the same.